### PR TITLE
Allow the use of a local PEV2 source

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,9 @@ import { emptyDir } from "rollup-plugin-empty-dir";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue(), emptyDir()],
+  resolve: {
+    dedupe: ["vue"],
+  },
   build: {
     manifest: true,
     rollupOptions: {


### PR DESCRIPTION
This prevent errors like:
Cannot read property 'isCE' of null

When using 'npm link ../pev2' to test a local version of pev2