### PR TITLE
Add workflow to publish docker image for self-hosting

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -36,5 +36,5 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' }}
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository_owner }}/pev2-server:${{ env.TAG }}
-            ghcr.io/${{ github.repository_owner }}/pev2-server:latest
+            ghcr.io/${{ github.repository_owner }}/pev2:${{ env.TAG }}
+            ghcr.io/${{ github.repository_owner }}/pev2:latest

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -1,0 +1,40 @@
+name: "Publish"
+on:
+  workflow_dispatch:
+  # Run on PRs to main to make sure everything works, but we skip the publishing.
+  pull_request:
+    branches:
+      - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Checkout latest tag
+        run: |
+          git fetch --tags
+          TAG=$(git tag -l --sort=v:refname | tail -1)
+          echo "TAG=$TAG" >> $GITHUB_ENV
+          git checkout $TAG
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.ref == 'refs/heads/main' }}
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/pev2-server:${{ env.TAG }}
+            ghcr.io/${{ github.repository_owner }}/pev2-server:latest


### PR DESCRIPTION
Re: #26 

Pretty straightforward: checkout the latest tag, build the docker image for the Python flask application, and publish it to Github's container registry, using the git tag as the image tag.

Here's how it looks when it runs: https://github.com/alexklibisz/explain.dalibo.com/actions/runs/8943147452

Here's how it looks when the image is published: https://github.com/alexklibisz/explain.dalibo.com/pkgs/container/pev2/versions

We might want to adjust the name. I chose `pev2` for now, but perhaps you want to call it something else.