### PR TITLE
Use $dark for background for tippy tooltips

### DIFF
--- a/app/static/css/custom.scss
+++ b/app/static/css/custom.scss
@@ -15,3 +15,10 @@ $body-color: #495057;
     color: $link-color;
   }
 }
+
+.tippy-box {
+  background-color: $dark !important;
+}
+.tippy-arrow {
+  color: $dark !important;
+}


### PR DESCRIPTION
This prevents color weirdness for the background of the tables in tooltips.
![Screenshot from 2024-10-09 16-17-51](https://github.com/user-attachments/assets/66bddeb6-5898-46e2-9ae3-cc820ddecf29)

![Screenshot from 2024-10-09 16-18-33](https://github.com/user-attachments/assets/5bc660b9-c71d-4cdd-b613-bc68b1ebe931)

